### PR TITLE
Remove unhelpful sentence

### DIFF
--- a/Contextual_bandits_and_Vowpal_Wabbit.ipynb
+++ b/Contextual_bandits_and_Vowpal_Wabbit.ipynb
@@ -85,7 +85,7 @@
     "2. `--cb_explore`  \n",
     "  The contextual bandit learning algorithm for when the maximum number of actions is known ahead of time and semantics of actions stays the same across examples.\n",
     "3. `--cb_explore_adf`  \n",
-    "  The contextual bandit learning algorithm for when the set of actions changes over time or you have rich information for each action. Vowpal Wabbit offers different input formats for contextual bandits.\n",
+    "  The contextual bandit learning algorithm for when the set of actions changes over time or you have rich information for each action.\n",
     "\n",
     "### Input format for `--cb`\n",
     "\n",


### PR DESCRIPTION
The sentence doesn't add any information. And it was awkwardly placed: it was rendered as part of the description of `--cb_explore_adf`, but it wasn't specific to it.